### PR TITLE
Updated Dockerfile to strip the bins/libs after creation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
 FROM ubuntu:latest
 
-ADD . /root/pharos
+RUN (apt-get -y update && apt-get upgrade -y)
+RUN (apt-get -y install sudo build-essential wget flex ghostscript bzip2 git subversion automake libtool bison python libncurses5-dev vim-common libsqlite3-0 libsqlite3-dev)
 
-RUN apt-get -y update
-RUN apt-get -y install sudo build-essential wget flex ghostscript bzip2 git subversion automake libtool bison python libncurses5-dev vim-common libsqlite3-0 libsqlite3-dev
+COPY ./ /usr/local/src/pharos
 
-RUN /root/pharos/scripts/build.bash
-
-
+# Put everyting in the same layer.  Otherwise when we strip the layer is still 1.7GB
+RUN (/usr/local/src/pharos/scripts/build.bash && \
+rm -rf /usr/local/src/pharos && \
+cd /usr/local/lib && \
+find /usr/local/lib | xargs file | grep 'current ar archive' | awk -F':' '{print $1}' | xargs strip && \
+find /usr/local/lib | xargs file | grep ELF | awk -F':' '{print $1}' | xargs strip && \
+find /usr/local/bin | xargs file | grep ELF | awk -F':' '{print $1}' | xargs strip )


### PR DESCRIPTION
This reduces the size of the final pharos docker image from 1.7GB to ~960MB