### PR TITLE
fixed svn checkout that would never succeed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ TAGS
 *.pyc
 *.xwam
 
+# SVN imports
+/scripts/XSB
+
 # generated files and binaries
 /libpharos/PHAROS_REVISION
 /libpharos/PHAROS_REVISION.ii

--- a/scripts/build.bash
+++ b/scripts/build.bash
@@ -12,12 +12,21 @@ test -d XSB && sudo rm -rf XSB
 
 # XSB frequently fails to clone, so try very hard to clone with reasonable timeouts in between
 RETRY=100
-while svn checkout https://svn.code.sf.net/p/xsb/src/trunk/XSB XSB; test $? -eq 1 -a $RETRY -gt 0
-do
+if svn checkout https://svn.code.sf.net/p/xsb/src/trunk/XSB XSB; status=$?; then
+    echo svn checkout incomplete
+fi
+
+while [ $status -ne 0 -a $RETRY -gt 0 ]; do
     RETRY=$(($RETRY-1))
-    echo SVN checkout failed.  Sleeping and trying again.
-    sleep 60
-    rm -rf XSB
+    echo SVN update needed
+    sleep 5
+
+    pushd XSB
+        svn cleanup
+        if svn update; status=$?; then
+            echo svn update incomplete
+        fi
+    popd 
 done
 
 # Pre-create the XSB install target and give the user write access.


### PR DESCRIPTION
Instead of repeatedly trying `svn checkout`, do this instead (pseudo-code below)

```python
svn checkout
while not done:
    svn cleanup
    svn update
```

I edited the install.bash script to basically do that.  See this [stack overflow discussion](https://stackoverflow.com/questions/27267742/why-do-i-get-svn-e120106-ra-serf-the-server-sent-a-truncated-http-response-b) for more details.  The `svn update` command does not try to do a complete fetch, but tries to update only the remaining files.

I also added scripts/XSB to .gitignore