### PR TITLE
Fix typo in oodebugrun-swipl-noguess

### DIFF
--- a/share/prolog/oorules/oodebugrun-swipl-noguess.in
+++ b/share/prolog/oorules/oodebugrun-swipl-noguess.in
@@ -1,4 +1,4 @@
 #!/bin/bash
 @SWIPL_HEADER@
-@SWIPL_PROGRAM@ -g "set_prolog_flag(stack_limit, $STACK_LIMIT),set_prolog_flag(table_space, $TABLE_SPACE),asserta(library_directory('$DIR')),,assert(logLevel(@PHAROS_OOLOGLEVEL@))['$DIR/report.P'],assert(rTTIEnabled),assert(guessingDisabled),psolve('${1}')."
+@SWIPL_PROGRAM@ -g "set_prolog_flag(stack_limit, $STACK_LIMIT),set_prolog_flag(table_space, $TABLE_SPACE),asserta(library_directory('$DIR')),assert(logLevel(@PHAROS_OOLOGLEVEL@)),['$DIR/report.P'],assert(rTTIEnabled),assert(guessingDisabled),psolve('${1}')."
 


### PR DESCRIPTION
Update misplaced a comma, causing prolog syntax error.