### PR TITLE
Add necessary step in build instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -48,10 +48,16 @@ $ sudo apt install build-essential wget flex ghostscript bzip2 \
   libyaml-cpp-dev libboost-all-dev libboost-dev libxml2-dev
 ```
 
-Then run the script:
+Then install all dependencies by running:
+```
+./scripts/build_prereqs.bash
+```
+
+And finally run the script:
 ```
 NCPU=4 ./scripts/build.bash
 ```
+
 Set `NCPU` to the number of cores you wish to use for building.  You
 should probably use 1 unless you have a lot of RAM.
 


### PR DESCRIPTION
`build_prereqs.bash` needs to be called before `build.bash`.

This was tested on a freshly installed Debian image.