### PR TITLE
Fix github actions for pull requests

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,8 +5,9 @@ on:
     branches:
       - '*'
   pull_request:
-  pull_request_target:
-    types: [labeled]
+  # Enabling this has some security implications.  For now we'll leave it off.
+  #pull_request_target:
+  #  types: [labeled]
   schedule:
     - cron: '42 06 * * sat' # Run every Saturday at 06:42 UTC
 


### PR DESCRIPTION
Github actions will no longer attempt to push for PRs, unless the "safe to push to docker" label is set.