### PR TITLE
chore: update Boost artifact URL to archives.boost.io

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -127,7 +127,7 @@ You can build Boost using these commands:
 ```
 $ mkdir boost
 $ cd boost
-$ wget https://boostorg.jfrog.io/artifactory/main/release/1.64.0/source/boost_1_64_0.tar.bz2
+$ wget https://archives.boost.io/release/1.64.0/source/boost_1_64_0.tar.bz2
 $ tar -xjvf boost_1_64_0.tar.bz2
 $ cd boost_1_64_0
 $ ./bootstrap.sh --prefix=/usr/local

--- a/scripts/build_prereqs.bash
+++ b/scripts/build_prereqs.bash
@@ -13,8 +13,7 @@ then
    test -d boost && sudo rm -rf boost
    mkdir boost
    cd boost
-   wget https://versaweb.dl.sourceforge.net/project/boost/boost/1.64.0/boost_1_64_0.tar.bz2
-   #wget https://boostorg.jfrog.io/artifactory/main/release/1.64.0/source/boost_1_64_0.tar.bz2
+   wget https://archives.boost.io/release/1.64.0/source/boost_1_64_0.tar.bz2
    tar -xjf boost_1_64_0.tar.bz2
    cd boost_1_64_0
    ./bootstrap.sh --prefix=$PREFIX --with-libraries=system,serialization,chrono,timer,iostreams,thread,date_time,random,regex,program_options,filesystem,wave


### PR DESCRIPTION
This pull request updates Boost artifact URL(s) from `boostorg.jfrog.io/artifactory/main/release` to `archives.boost.io/release`.

Boost have changed to a new download provider, and the old JFrog URLs are no longer available: https://github.com/boostorg/boost/issues/996